### PR TITLE
refactor: update for ibis 3.x and add in substrait checks

### DIFF
--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -47,3 +47,22 @@ jobs:
       - run: pip uninstall -y ibis-framework
       - run: pip install --upgrade 'git+https://github.com/ibis-project/ibis.git@master'
       - run: ./runtpc -i sqlite -i ibis
+
+  duckdb-tpc-queries-ibis-master:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: install python
+        uses: actions/setup-python@v3
+        id: install_python
+        with:
+          python-version: "3.9"
+
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements.txt
+      - run: pip uninstall -y ibis-framework
+      - run: pip install --upgrade 'git+https://github.com/ibis-project/ibis.git@master'
+      - run: python -c "import duckdb; con = duckdb.connect('tpch.ddb'); con.execute('CALL dbgen(sf=0.1);')"
+      - run: ./runtpc -i duckdb -i ibis -d 'tpch.ddb' -b 'duckdb'

--- a/duckdb_tpc/h01.sql
+++ b/duckdb_tpc/h01.sql
@@ -1,0 +1,16 @@
+SELECT l_returnflag,
+       l_linestatus,
+       sum(l_quantity) AS sum_qty,
+       sum(l_extendedprice) AS sum_base_price,
+       sum(l_extendedprice*(1-l_discount)) AS sum_disc_price,
+       sum(l_extendedprice*(1-l_discount)*(1+l_tax)) AS sum_charge,
+       avg(l_quantity) AS avg_qty,
+       avg(l_extendedprice) AS avg_price,
+       avg(l_discount) AS avg_disc,
+       count(*) AS count_order
+FROM lineitem
+WHERE l_shipdate <= '1998-09-01'  -- date '1998-12-01' - interval '[DELTA=90]' DAY
+GROUP BY l_returnflag,
+         l_linestatus
+ORDER BY l_returnflag,
+         l_linestatus;

--- a/duckdb_tpc/h02.sql
+++ b/duckdb_tpc/h02.sql
@@ -1,0 +1,37 @@
+SELECT s_acctbal,
+       s_name,
+       n_name,
+       p_partkey,
+       p_mfgr,
+       s_address,
+       s_phone,
+       s_comment
+FROM part,
+     supplier,
+     partsupp,
+     nation,
+     region
+WHERE p_partkey = ps_partkey
+  AND s_suppkey = ps_suppkey
+  AND p_size = 25 -- [SIZE]
+  AND p_type like '%BRASS' -- '%[TYPE]'
+  AND s_nationkey = n_nationkey
+  AND n_regionkey = r_regionkey
+  AND r_name = 'EUROPE' -- '[REGION]'
+  AND ps_supplycost =
+    (SELECT min(ps_supplycost)
+     FROM partsupp,
+          supplier,
+          nation,
+          region
+     WHERE p_partkey = ps_partkey
+       AND s_suppkey = ps_suppkey
+       AND s_nationkey = n_nationkey
+       AND n_regionkey = r_regionkey
+       AND r_name = 'EUROPE') -- '[REGION]' )
+ORDER BY s_acctbal DESC,
+         n_name,
+         s_name,
+         p_partkey
+LIMIT 100
+;

--- a/duckdb_tpc/h03.sql
+++ b/duckdb_tpc/h03.sql
@@ -1,0 +1,19 @@
+SELECT l_orderkey,
+       sum(l_extendedprice * (1 - l_discount)) AS revenue,
+       o_orderdate,
+       o_shippriority
+FROM customer,
+     orders,
+     lineitem
+WHERE c_mktsegment = 'BUILDING'
+  AND c_custkey = o_custkey
+  AND l_orderkey = o_orderkey
+  AND o_orderdate < '1995-03-15'
+  AND l_shipdate > '1995-03-15'
+GROUP BY l_orderkey,
+         o_orderdate,
+         o_shippriority
+ORDER BY revenue DESC,
+         o_orderdate
+LIMIT 10
+;

--- a/duckdb_tpc/h04.sql
+++ b/duckdb_tpc/h04.sql
@@ -1,0 +1,13 @@
+SELECT o_orderpriority,
+       count(*) AS order_count
+FROM orders
+WHERE o_orderdate >= '1993-07-01'
+  AND o_orderdate < '1993-10-01'
+  AND EXISTS
+    (SELECT *
+     FROM lineitem
+     WHERE l_orderkey = o_orderkey
+       AND l_commitdate < l_receiptdate )
+GROUP BY o_orderpriority
+ORDER BY o_orderpriority
+;

--- a/duckdb_tpc/h05.sql
+++ b/duckdb_tpc/h05.sql
@@ -1,0 +1,20 @@
+SELECT n_name,
+       sum(l_extendedprice * (1 - l_discount)) AS revenue
+FROM customer,
+     orders,
+     lineitem,
+     supplier,
+     nation,
+     region
+WHERE c_custkey = o_custkey
+  AND l_orderkey = o_orderkey
+  AND l_suppkey = s_suppkey
+  AND c_nationkey = s_nationkey
+  AND s_nationkey = n_nationkey
+  AND n_regionkey = r_regionkey
+  AND r_name = 'ASIA'
+  AND o_orderdate >= '1994-01-01'
+  AND o_orderdate < '1995-01-01'
+GROUP BY n_name
+ORDER BY revenue DESC
+;

--- a/duckdb_tpc/h06.sql
+++ b/duckdb_tpc/h06.sql
@@ -1,0 +1,7 @@
+SELECT sum(l_extendedprice * l_discount) AS revenue
+FROM lineitem
+WHERE l_shipdate >= '1994-01-01'
+  AND l_shipdate < '1995-01-01'
+  AND l_discount BETWEEN 0.05 AND 0.07
+  AND l_quantity < 24
+;

--- a/duckdb_tpc/h07.sql
+++ b/duckdb_tpc/h07.sql
@@ -1,0 +1,32 @@
+SELECT supp_nation,
+       cust_nation,
+       l_year,
+       sum(volume) AS revenue
+FROM
+  (SELECT n1.n_name AS supp_nation,
+          n2.n_name AS cust_nation,
+          strftime(l_shipdate, '%Y') AS l_year,
+          l_extendedprice * (1 - l_discount) AS volume
+   FROM supplier,
+        lineitem,
+        orders,
+        customer,
+        nation n1,
+        nation n2
+   WHERE s_suppkey = l_suppkey
+     AND o_orderkey = l_orderkey
+     AND c_custkey = o_custkey
+     AND s_nationkey = n1.n_nationkey
+     AND c_nationkey = n2.n_nationkey
+     AND ((n1.n_name = 'FRANCE'
+           AND n2.n_name = 'GERMANY')
+          OR (n1.n_name = 'GERMANY'
+              AND n2.n_name = 'FRANCE'))
+     AND l_shipdate BETWEEN '1995-01-01' AND '1996-12-31' ) AS shipping
+GROUP BY supp_nation,
+         cust_nation,
+         l_year
+ORDER BY supp_nation,
+         cust_nation,
+         l_year
+;

--- a/duckdb_tpc/h08.sql
+++ b/duckdb_tpc/h08.sql
@@ -1,0 +1,30 @@
+SELECT o_year,
+       sum(CASE
+               WHEN nation = 'BRAZIL' THEN volume
+               ELSE 0
+           END) / sum(volume) AS mkt_share
+FROM
+  (SELECT strftime(o_orderdate, '%Y') AS o_year,
+          l_extendedprice * (1 - l_discount) AS volume,
+          n2.n_name AS nation
+   FROM part,
+        supplier,
+        lineitem,
+        orders,
+        customer,
+        nation n1,
+        nation n2,
+        region
+   WHERE p_partkey = l_partkey
+     AND s_suppkey = l_suppkey
+     AND l_orderkey = o_orderkey
+     AND o_custkey = c_custkey
+     AND c_nationkey = n1.n_nationkey
+     AND n1.n_regionkey = r_regionkey
+     AND r_name = 'AMERICA'
+     AND s_nationkey = n2.n_nationkey
+     AND o_orderdate BETWEEN '1995-01-01' AND '1996-12-31'
+     AND p_type = 'ECONOMY ANODIZED STEEL' ) AS all_nations
+GROUP BY o_year
+ORDER BY o_year
+;

--- a/duckdb_tpc/h09.sql
+++ b/duckdb_tpc/h09.sql
@@ -1,0 +1,24 @@
+SELECT nation,
+       o_year,
+       sum(amount) AS sum_profit
+FROM
+  (SELECT n_name AS nation,
+          strftime(o_orderdate, '%Y') AS o_year,
+          l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity AS amount
+   FROM part,
+        supplier,
+        lineitem,
+        partsupp,
+        orders,
+        nation
+   WHERE s_suppkey = l_suppkey
+     AND ps_suppkey = l_suppkey
+     AND ps_partkey = l_partkey
+     AND p_partkey = l_partkey
+     AND o_orderkey = l_orderkey
+     AND s_nationkey = n_nationkey
+     AND p_name like '%green%' ) AS profit
+GROUP BY nation,
+         o_year
+ORDER BY nation,
+         o_year DESC ;

--- a/duckdb_tpc/h10.sql
+++ b/duckdb_tpc/h10.sql
@@ -1,0 +1,27 @@
+SELECT c_custkey,
+       c_name,
+       sum(l_extendedprice * (1 - l_discount)) AS revenue,
+       c_acctbal,
+       n_name,
+       c_address,
+       c_phone,
+       c_comment
+FROM customer,
+     orders,
+     lineitem,
+     nation
+WHERE c_custkey = o_custkey
+  AND l_orderkey = o_orderkey
+  AND o_orderdate >= '1993-10-01'
+  AND o_orderdate < '1994-01-01'
+  AND l_returnflag = 'R'
+  AND c_nationkey = n_nationkey
+GROUP BY c_custkey,
+         c_name,
+         c_acctbal,
+         c_phone,
+         n_name,
+         c_address,
+         c_comment
+ORDER BY revenue DESC
+LIMIT 20 ;

--- a/duckdb_tpc/h11.sql
+++ b/duckdb_tpc/h11.sql
@@ -1,0 +1,19 @@
+SELECT ps_partkey,
+       sum(ps_supplycost * ps_availqty) AS value
+FROM partsupp,
+     supplier,
+     nation
+WHERE ps_suppkey = s_suppkey
+  AND s_nationkey = n_nationkey
+  AND n_name = 'GERMANY'
+GROUP BY ps_partkey
+HAVING sum(ps_supplycost * ps_availqty) >
+  (SELECT sum(ps_supplycost * ps_availqty) * .0001 -- FRACTION = .0001/SF
+FROM partsupp,
+     supplier,
+     nation
+   WHERE ps_suppkey = s_suppkey
+     AND s_nationkey = n_nationkey
+     AND n_name = 'GERMANY' )
+ORDER BY value DESC
+;

--- a/duckdb_tpc/h12.sql
+++ b/duckdb_tpc/h12.sql
@@ -1,0 +1,23 @@
+SELECT l_shipmode,
+       sum(CASE
+               WHEN o_orderpriority ='1-URGENT'
+                    OR o_orderpriority ='2-HIGH' THEN 1
+               ELSE 0
+           END) AS high_line_count,
+       sum(CASE
+               WHEN o_orderpriority <> '1-URGENT'
+                    AND o_orderpriority <> '2-HIGH' THEN 1
+               ELSE 0
+           END) AS low_line_count
+FROM orders,
+     lineitem
+WHERE o_orderkey = l_orderkey
+  AND l_shipmode in ('MAIL',
+                     'SHIP')
+  AND l_commitdate < l_receiptdate
+  AND l_shipdate < l_commitdate
+  AND l_receiptdate >= '1994-01-01'
+  AND l_receiptdate < '1995-01-01'
+GROUP BY l_shipmode
+ORDER BY l_shipmode
+;

--- a/duckdb_tpc/h13.sql
+++ b/duckdb_tpc/h13.sql
@@ -1,0 +1,13 @@
+SELECT c_count,
+       count(*) AS custdist
+FROM
+  (SELECT c_custkey,
+          count(o_orderkey) AS c_count
+   FROM customer
+   LEFT OUTER JOIN orders ON c_custkey = o_custkey
+   AND o_comment NOT LIKE '%special%requests%'
+   GROUP BY c_custkey)
+GROUP BY c_count
+ORDER BY custdist DESC,
+         c_count DESC
+;

--- a/duckdb_tpc/h14.sql
+++ b/duckdb_tpc/h14.sql
@@ -1,0 +1,10 @@
+SELECT 100.00 * sum(CASE
+                        WHEN p_type like 'PROMO%' THEN l_extendedprice*(1-l_discount)
+                        ELSE 0
+                    END) / sum(l_extendedprice * (1 - l_discount)) AS promo_revenue
+FROM lineitem,
+     part
+WHERE l_partkey = p_partkey
+  AND l_shipdate >= '1995-09-01'
+  AND l_shipdate < '1995-10-01'
+;

--- a/duckdb_tpc/h15.sql
+++ b/duckdb_tpc/h15.sql
@@ -1,0 +1,25 @@
+SELECT s_suppkey,
+       s_name,
+       s_address,
+       s_phone,
+       total_revenue
+FROM supplier,
+
+  (SELECT l_suppkey AS supplier_no,
+          sum(l_extendedprice * (1 - l_discount)) AS total_revenue
+   FROM lineitem
+   WHERE l_shipdate >= '1996-01-01'
+     AND l_shipdate < '1996-04-01'
+   GROUP BY supplier_no) revenue0
+WHERE s_suppkey = supplier_no
+  AND total_revenue =
+    (SELECT max(total_revenue)
+     FROM
+       (SELECT l_suppkey AS supplier_no,
+               sum(l_extendedprice * (1 - l_discount)) AS total_revenue
+        FROM lineitem
+        WHERE l_shipdate >= '1996-01-01'
+          AND l_shipdate < '1996-04-01'
+        GROUP BY supplier_no) revenue1)
+ORDER BY s_suppkey
+;

--- a/duckdb_tpc/h16.sql
+++ b/duckdb_tpc/h16.sql
@@ -1,0 +1,22 @@
+SELECT p_brand,
+       p_type,
+       p_size,
+       count(DISTINCT ps_suppkey) AS supplier_cnt
+FROM partsupp,
+     part
+WHERE p_partkey = ps_partkey
+  AND p_brand <> 'Brand#45'
+  AND p_type not like 'MEDIUM POLISHED%'
+  AND p_size in (49, 14, 23, 45, 19, 3, 36, 9)
+  AND ps_suppkey not in
+    (SELECT s_suppkey
+     FROM supplier
+     WHERE s_comment like '%Customer%Complaints%' )
+GROUP BY p_brand,
+         p_type,
+         p_size
+ORDER BY supplier_cnt DESC,
+         p_brand,
+         p_type,
+         p_size
+;

--- a/duckdb_tpc/h17.sql
+++ b/duckdb_tpc/h17.sql
@@ -1,0 +1,11 @@
+SELECT sum(l_extendedprice) / 7.0 AS avg_yearly
+FROM lineitem,
+     part
+WHERE p_partkey = l_partkey
+  AND p_brand = 'Brand#23'
+  AND p_container = 'MED BOX'
+  AND l_quantity <
+    (SELECT 0.2 * avg(l_quantity)
+     FROM lineitem
+     WHERE l_partkey = p_partkey )
+;

--- a/duckdb_tpc/h18.sql
+++ b/duckdb_tpc/h18.sql
@@ -1,0 +1,25 @@
+SELECT c_name,
+       c_custkey,
+       o_orderkey,
+       o_orderdate,
+       o_totalprice,
+       sum(l_quantity) AS sum_qty
+FROM customer,
+     orders,
+     lineitem
+WHERE o_orderkey in
+    (SELECT l_orderkey
+     FROM lineitem
+     GROUP BY l_orderkey
+     HAVING sum(l_quantity) > 300)
+  AND c_custkey = o_custkey
+  AND o_orderkey = l_orderkey
+GROUP BY c_name,
+         c_custkey,
+         o_orderkey,
+         o_orderdate,
+         o_totalprice
+ORDER BY o_totalprice DESC,
+         o_orderdate
+LIMIT 100
+;

--- a/duckdb_tpc/h19.sql
+++ b/duckdb_tpc/h19.sql
@@ -1,0 +1,40 @@
+SELECT sum(l_extendedprice * (1 - l_discount)) AS revenue
+FROM lineitem,
+     part
+WHERE (p_partkey = l_partkey
+       AND p_brand = 'Brand#12'
+       AND p_container in ('SM CASE',
+                           'SM BOX',
+                           'SM PACK',
+                           'SM PKG')
+       AND l_quantity >= 1
+       AND l_quantity <= 11
+       AND p_size BETWEEN 1 AND 5
+       AND l_shipmode in ('AIR',
+                          'AIR REG')
+       AND l_shipinstruct = 'DELIVER IN PERSON')
+  OR (p_partkey = l_partkey
+      AND p_brand = 'Brand#23'
+      AND p_container in ('MED BAG',
+                          'MED BOX',
+                          'MED PKG',
+                          'MED PACK')
+      AND l_quantity >= 10
+      AND l_quantity <= 20
+      AND p_size BETWEEN 1 AND 10
+      AND l_shipmode in ('AIR',
+                         'AIR REG')
+      AND l_shipinstruct = 'DELIVER IN PERSON')
+  OR (p_partkey = l_partkey
+      AND p_brand = 'Brand#34'
+      AND p_container in ('LG CASE',
+                          'LG BOX',
+                          'LG PACK',
+                          'LG PKG')
+      AND l_quantity >= 20
+      AND l_quantity <= 30
+      AND p_size BETWEEN 1 AND 15
+      AND l_shipmode in ('AIR',
+                         'AIR REG')
+      AND l_shipinstruct = 'DELIVER IN PERSON')
+;

--- a/duckdb_tpc/h20.sql
+++ b/duckdb_tpc/h20.sql
@@ -1,0 +1,22 @@
+SELECT s_name,
+       s_address
+FROM supplier,
+     nation
+WHERE s_suppkey in
+    (SELECT ps_suppkey
+     FROM partsupp
+     WHERE ps_partkey in
+         (SELECT p_partkey
+          FROM part
+          WHERE p_name like 'forest%' )
+       AND ps_availqty >
+         (SELECT 0.5 * sum(l_quantity)
+          FROM lineitem
+          WHERE l_partkey = ps_partkey
+            AND l_suppkey = ps_suppkey
+            AND l_shipdate >= '1994-01-01'
+            AND l_shipdate < '1995-01-01' ) )
+  AND s_nationkey = n_nationkey
+  AND n_name = 'CANADA'
+ORDER BY s_name
+;

--- a/duckdb_tpc/h21.sql
+++ b/duckdb_tpc/h21.sql
@@ -1,0 +1,28 @@
+SELECT s_name,
+       count(*) AS numwait
+FROM supplier,
+     lineitem l1,
+     orders,
+     nation
+WHERE s_suppkey = l1.l_suppkey
+  AND o_orderkey = l1.l_orderkey
+  AND o_orderstatus = 'F'
+  AND l1.l_receiptdate > l1.l_commitdate
+  AND EXISTS
+    (SELECT *
+     FROM lineitem l2
+     WHERE l2.l_orderkey = l1.l_orderkey
+       AND l2.l_suppkey <> l1.l_suppkey )
+  AND NOT EXISTS
+    (SELECT *
+     FROM lineitem l3
+     WHERE l3.l_orderkey = l1.l_orderkey
+       AND l3.l_suppkey <> l1.l_suppkey
+       AND l3.l_receiptdate > l3.l_commitdate )
+  AND s_nationkey = n_nationkey
+  AND n_name = 'SAUDI ARABIA'
+GROUP BY s_name
+ORDER BY numwait DESC,
+         s_name
+LIMIT 100
+;

--- a/duckdb_tpc/h22.sql
+++ b/duckdb_tpc/h22.sql
@@ -1,0 +1,22 @@
+SELECT cntrycode,
+       COUNT(*) AS numcust,
+       SUM(c_acctbal) AS totacctbal
+FROM
+  (SELECT SUBSTR(c_phone, 1, 2) AS cntrycode,
+          c_acctbal
+   FROM customer
+   WHERE SUBSTR(c_phone, 1, 2)
+        IN ('13', '31', '23', '29', '30', '18', '17')
+     AND c_acctbal >
+       (SELECT AVG(c_acctbal)
+        FROM customer
+        WHERE c_acctbal > 0.00
+          AND SUBSTR(c_phone, 1, 2)
+            IN ('13', '31', '23', '29', '30', '18', '17') )
+     AND NOT EXISTS
+       (SELECT *
+        FROM orders
+        WHERE o_custkey = c_custkey ) ) AS custsale
+GROUP BY cntrycode
+ORDER BY cntrycode
+;

--- a/ibis_tpc/h01.py
+++ b/ibis_tpc/h01.py
@@ -1,11 +1,9 @@
-'Pricing Summary Report Query (Q1)'
+"Pricing Summary Report Query (Q1)"
+from .utils import add_date
 
 
-from datetime import date, timedelta
-
-
-def tpc_h01(con, DELTA=90):
-    '''
+def tpc_h01(con, DELTA=-90, DATE="1998-12-01"):
+    """
     The Pricing Summary Report Query provides a summary pricing report for all
     lineitems shipped as of a given date.  The  date is  within  60  - 120 days
     of  the  greatest  ship  date  contained  in  the database.  The query
@@ -14,23 +12,33 @@ def tpc_h01(con, DELTA=90):
     average discount.  These  aggregates  are grouped  by RETURNFLAG  and
     LINESTATUS, and  listed  in ascending  order of RETURNFLAG and  LINESTATUS.
     A  count  of the  number  of  lineitems in each  group  is included.
-    '''
+    """
 
-    t = con.table('lineitem')
+    lineitem = con.table("lineitem")
 
-    interval = date.fromisoformat('1998-12-01') - timedelta(days=DELTA)
-    q = t.filter(t.l_shipdate < interval)
-    discount_price = t.l_extendedprice*(1-t.l_discount)
-    charge = discount_price*(1+t.l_tax)
-    q = q.group_by(['l_returnflag', 'l_linestatus'])
-    q = q.order_by(['l_returnflag', 'l_linestatus'])
-    q = q.aggregate(sum_qty=t.l_quantity.sum(),
-                    sum_base_price=t.l_extendedprice.sum(),
-                    sum_disc_price=discount_price.sum(),
-                    sum_charge=charge.sum(),
-                    avg_qty=t.l_quantity.mean(),
-                    avg_price=t.l_extendedprice.mean(),
-                    avg_disc=t.l_discount.mean(),
-                    count_order=t.count(),
-                    )
+    tables = (lineitem,)
+
+    return _tpc_h01(tables, DELTA, DATE)
+
+
+def _tpc_h01(tables, DELTA=-90, DATE="1998-12-01"):
+
+    lineitem, = tables
+
+    interval = add_date(DATE, dd=DELTA)
+    q = lineitem.filter(lineitem.l_shipdate < interval)
+    discount_price = lineitem.l_extendedprice * (1 - lineitem.l_discount)
+    charge = discount_price * (1 + lineitem.l_tax)
+    q = q.group_by(["l_returnflag", "l_linestatus"])
+    q = q.order_by(["l_returnflag", "l_linestatus"])
+    q = q.aggregate(
+        sum_qty=lineitem.l_quantity.sum(),
+        sum_base_price=lineitem.l_extendedprice.sum(),
+        sum_disc_price=discount_price.sum(),
+        sum_charge=charge.sum(),
+        avg_qty=lineitem.l_quantity.mean(),
+        avg_price=lineitem.l_extendedprice.mean(),
+        avg_disc=lineitem.l_discount.mean(),
+        count_order=lineitem.count(),
+    )
     return q

--- a/ibis_tpc/h02.py
+++ b/ibis_tpc/h02.py
@@ -1,55 +1,66 @@
 import ibis
 
 
-def tpc_h02(con, REGION='EUROPE', SIZE=25, TYPE='BRASS'):
-    'Minimum Cost Supplier Query (Q2)'
-
+def tpc_h02(con, REGION="EUROPE", SIZE=25, TYPE="BRASS"):
     part = con.table("part")
     supplier = con.table("supplier")
     partsupp = con.table("partsupp")
     nation = con.table("nation")
     region = con.table("region")
 
+    tables = (part, supplier, partsupp, nation, region)
+
+    return _tpc_h02(tables, REGION, SIZE, TYPE)
+
+
+def _tpc_h02(tables, REGION="EUROPE", SIZE=25, TYPE="BRASS"):
+    "Minimum Cost Supplier Query (Q2)"
+
+    part, supplier, partsupp, nation, region = tables
+
     expr = (
         part.join(partsupp, part.p_partkey == partsupp.ps_partkey)
         .join(supplier, supplier.s_suppkey == partsupp.ps_suppkey)
         .join(nation, supplier.s_nationkey == nation.n_nationkey)
         .join(region, nation.n_regionkey == region.r_regionkey)
-    ).materialize()
+    )
 
     subexpr = (
         partsupp.join(supplier, supplier.s_suppkey == partsupp.ps_suppkey)
         .join(nation, supplier.s_nationkey == nation.n_nationkey)
         .join(region, nation.n_regionkey == region.r_regionkey)
-    ).materialize()
+    )
 
-    subexpr = subexpr[(subexpr.r_name == REGION) &
-                      (expr.p_partkey == subexpr.ps_partkey)]
+    subexpr = subexpr[
+        (subexpr.r_name == REGION) & (expr.p_partkey == subexpr.ps_partkey)
+    ]
 
     filters = [
         expr.p_size == SIZE,
-        expr.p_type.like("%"+TYPE),
+        expr.p_type.like("%" + TYPE),
         expr.r_name == REGION,
-        expr.ps_supplycost == subexpr.ps_supplycost.min()
+        expr.ps_supplycost == subexpr.ps_supplycost.min(),
     ]
     q = expr.filter(filters)
 
-    q = q.select([
-        q.s_acctbal,
-        q.s_name,
-        q.n_name,
-        q.p_partkey,
-        q.p_mfgr,
-        q.s_address,
-        q.s_phone,
-        q.s_comment,
-    ])
+    q = q.select(
+        [
+            q.s_acctbal,
+            q.s_name,
+            q.n_name,
+            q.p_partkey,
+            q.p_mfgr,
+            q.s_address,
+            q.s_phone,
+            q.s_comment,
+        ]
+    )
 
     return q.sort_by(
-                [
-                    ibis.desc(q.s_acctbal),
-                    q.n_name,
-                    q.s_name,
-                    q.p_partkey,
-                ]
-            ).limit(100)
+        [
+            ibis.desc(q.s_acctbal),
+            q.n_name,
+            q.s_name,
+            q.p_partkey,
+        ]
+    ).limit(100)

--- a/ibis_tpc/h03.py
+++ b/ibis_tpc/h03.py
@@ -1,21 +1,27 @@
-'Shipping Priority Query (Q3)'
+"Shipping Priority Query (Q3)"
 
 
 import ibis
 
 
-def tpc_h03(con, MKTSEGMENT='BUILDING', DATE='1995-03-15'):
-    customer = con.table('customer')
-    orders = con.table('orders')
-    lineitem = con.table('lineitem')
+def tpc_h03(con, MKTSEGMENT="BUILDING", DATE="1995-03-15"):
+    customer = con.table("customer")
+    orders = con.table("orders")
+    lineitem = con.table("lineitem")
+
+    tables = customer, orders, lineitem
+
+    return _tpc_h03(tables, MKTSEGMENT, DATE)
+
+
+def _tpc_h03(tables, MKTSEGMENT="BUILDING", DATE="1995-03-15"):
+    customer, orders, lineitem = tables
 
     q = customer.join(orders, customer.c_custkey == orders.o_custkey)
-    q = q.join(lineitem, lineitem.l_orderkey == orders.o_orderkey).materialize()
-    q = q.filter([
-        q.c_mktsegment == MKTSEGMENT,
-        q.o_orderdate < DATE,
-        q.l_shipdate > DATE
-    ])
+    q = q.join(lineitem, lineitem.l_orderkey == orders.o_orderkey)
+    q = q.filter(
+        [q.c_mktsegment == MKTSEGMENT, q.o_orderdate < DATE, q.l_shipdate > DATE]
+    )
     qg = q.group_by([q.l_orderkey, q.o_orderdate, q.o_shippriority])
     q = qg.aggregate(revenue=(q.l_extendedprice * (1 - q.l_discount)).sum())
     q = q.sort_by([ibis.desc(q.revenue), q.o_orderdate])

--- a/ibis_tpc/h04.py
+++ b/ibis_tpc/h04.py
@@ -1,16 +1,28 @@
-'Order Priority Checking Query (Q4)'
+"Order Priority Checking Query (Q4)"
 
 from .utils import add_date
 
 
-def tpc_h04(con, DATE='1993-07-01'):
-    orders = con.table('orders')
-    lineitem = con.table('lineitem')
-    cond = ((lineitem.l_orderkey == orders.o_orderkey) &
-            (lineitem.l_commitdate < lineitem.l_receiptdate))
-    q = orders.filter([cond.any(),
-                       orders.o_orderdate >= DATE,
-                       orders.o_orderdate < add_date(DATE, dm=3)])
+def tpc_h04(con, DATE="1993-07-01"):
+    orders = con.table("orders")
+    lineitem = con.table("lineitem")
+
+    return _tpc_h04((orders, lineitem), DATE)
+
+
+def _tpc_h04(tables, DATE="1993-07-01"):
+    orders, lineitem = tables
+
+    cond = (lineitem.l_orderkey == orders.o_orderkey) & (
+        lineitem.l_commitdate < lineitem.l_receiptdate
+    )
+    q = orders.filter(
+        [
+            cond.any(),
+            orders.o_orderdate >= DATE,
+            orders.o_orderdate < add_date(DATE, dm=3),
+        ]
+    )
     q = q.group_by([orders.o_orderpriority])
     q = q.aggregate(order_count=orders.count())
     q = q.sort_by([orders.o_orderpriority])

--- a/ibis_tpc/h05.py
+++ b/ibis_tpc/h05.py
@@ -1,31 +1,40 @@
-'Local Supplier Volume Query (Q5)'
+"Local Supplier Volume Query (Q5)"
 
 import ibis
 
 from .utils import add_date
 
 
-def tpc_h05(con, NAME='ASIA', DATE='1994-01-01'):
-    customer = con.table('customer')
-    orders = con.table('orders')
-    lineitem = con.table('lineitem')
-    supplier = con.table('supplier')
-    nation = con.table('nation')
-    region = con.table('region')
+def tpc_h05(con, NAME="ASIA", DATE="1994-01-01"):
+    customer = con.table("customer")
+    orders = con.table("orders")
+    lineitem = con.table("lineitem")
+    supplier = con.table("supplier")
+    nation = con.table("nation")
+    region = con.table("region")
+
+    tables = (customer, orders, lineitem, supplier, nation, region)
+    return _tpc_h05(tables, NAME, DATE)
+
+
+def _tpc_h05(tables, NAME="ASIA", DATE="1994-01-01"):
+    customer, orders, lineitem, supplier, nation, region = tables
 
     q = customer
     q = q.join(orders, customer.c_custkey == orders.o_custkey)
     q = q.join(lineitem, lineitem.l_orderkey == orders.o_orderkey)
     q = q.join(supplier, lineitem.l_suppkey == supplier.s_suppkey)
-    q = q.join(nation, (customer.c_nationkey == supplier.s_nationkey) &
-                       (supplier.s_nationkey == nation.n_nationkey))
+    q = q.join(
+        nation,
+        (customer.c_nationkey == supplier.s_nationkey)
+        & (supplier.s_nationkey == nation.n_nationkey),
+    )
     q = q.join(region, nation.n_regionkey == region.r_regionkey)
-    q = q.materialize()
 
-    q = q.filter([q.r_name == NAME,
-                  q.o_orderdate >= DATE,
-                  q.o_orderdate < add_date(DATE, dy=1)])
-    revexpr = q.l_extendedprice*(1-q.l_discount)
+    q = q.filter(
+        [q.r_name == NAME, q.o_orderdate >= DATE, q.o_orderdate < add_date(DATE, dy=1)]
+    )
+    revexpr = q.l_extendedprice * (1 - q.l_discount)
     gq = q.group_by([q.n_name])
     q = gq.aggregate(revenue=revexpr.sum())
     q = q.sort_by([ibis.desc(q.revenue)])

--- a/ibis_tpc/h06.py
+++ b/ibis_tpc/h06.py
@@ -1,17 +1,29 @@
-'Forecasting Revenue Change Query (Q6)'
+"Forecasting Revenue Change Query (Q6)"
 
 from .utils import add_date
 
 
-def tpc_h06(con, DATE='1994-01-01', DISCOUNT=0.06, QUANTITY=24):
-    q = con.table('lineitem')
-    discount_min = round(DISCOUNT-.01, 2)
-    discount_max = round(DISCOUNT+.01, 2)
-    q = q.filter([
-                    q.l_shipdate >= DATE,
-                    q.l_shipdate < add_date(DATE, dy=1),
-                    q.l_discount.between(discount_min, discount_max),
-                    q.l_quantity < QUANTITY
-                    ])
-    q = q.aggregate(revenue=(q.l_extendedprice*q.l_discount).sum())
+def tpc_h06(con, DATE="1994-01-01", DISCOUNT=0.06, QUANTITY=24):
+    lineitem = con.table("lineitem")
+
+    tables = (lineitem,)
+
+    return _tpc_h06(tables, DATE, DISCOUNT, QUANTITY)
+
+
+def _tpc_h06(tables, DATE="1994-01-01", DISCOUNT=0.06, QUANTITY=24):
+
+    lineitem, = tables
+
+    discount_min = round(DISCOUNT - 0.01, 2)
+    discount_max = round(DISCOUNT + 0.01, 2)
+    q = lineitem.filter(
+        [
+            lineitem.l_shipdate >= DATE,
+            lineitem.l_shipdate < add_date(DATE, dy=1),
+            lineitem.l_discount.between(discount_min, discount_max),
+            lineitem.l_quantity < QUANTITY,
+        ]
+    )
+    q = q.aggregate(revenue=(q.l_extendedprice * q.l_discount).sum())
     return q

--- a/ibis_tpc/h07.py
+++ b/ibis_tpc/h07.py
@@ -1,15 +1,21 @@
-'Volume Shipping Query (Q7)'
+"Volume Shipping Query (Q7)"
 
 from .utils import add_date
 
 
-def tpc_h07(con, NATION1="FRANCE", NATION2="GERMANY", DATE='1995-01-01'):
-    supplier = con.table('supplier')
-    lineitem = con.table('lineitem')
-    orders = con.table('orders')
-    customer = con.table('customer')
-    nation = con.table('nation')
+def tpc_h07(con, NATION1="FRANCE", NATION2="GERMANY", DATE="1995-01-01"):
+    supplier = con.table("supplier")
+    lineitem = con.table("lineitem")
+    orders = con.table("orders")
+    customer = con.table("customer")
+    nation = con.table("nation")
 
+    tables = (supplier, lineitem, orders, customer, nation)
+    return _tpc_h07(tables, NATION1, NATION2, DATE)
+
+
+def _tpc_h07(tables, NATION1="FRANCE", NATION2="GERMANY", DATE="1995-01-01"):
+    supplier, lineitem, orders, customer, nation = tables
     q = supplier
     q = q.join(lineitem, supplier.s_suppkey == lineitem.l_suppkey)
     q = q.join(orders, orders.o_orderkey == lineitem.l_orderkey)
@@ -20,23 +26,25 @@ def tpc_h07(con, NATION1="FRANCE", NATION2="GERMANY", DATE='1995-01-01'):
     q = q.join(n2, customer.c_nationkey == n2.n_nationkey)
 
     q = q[
-            n1.n_name.name("supp_nation"),
-            n2.n_name.name("cust_nation"),
-            lineitem.l_shipdate,
-            lineitem.l_extendedprice,
-            lineitem.l_discount,
-            lineitem.l_shipdate.year().cast('string').name('l_year'),
-            (lineitem.l_extendedprice*(1-lineitem.l_discount)).name('volume')
+        n1.n_name.name("supp_nation"),
+        n2.n_name.name("cust_nation"),
+        lineitem.l_shipdate,
+        lineitem.l_extendedprice,
+        lineitem.l_discount,
+        lineitem.l_shipdate.year().cast("string").name("l_year"),
+        (lineitem.l_extendedprice * (1 - lineitem.l_discount)).name("volume"),
     ]
 
-    q = q.filter([
-        ((q.cust_nation == NATION1) & (q.supp_nation == NATION2)) |
-        ((q.cust_nation == NATION2) & (q.supp_nation == NATION1)),
-        q.l_shipdate.between(DATE, add_date(DATE, dy=2, dd=-1))
-        ])
+    q = q.filter(
+        [
+            ((q.cust_nation == NATION1) & (q.supp_nation == NATION2))
+            | ((q.cust_nation == NATION2) & (q.supp_nation == NATION1)),
+            q.l_shipdate.between(DATE, add_date(DATE, dy=2, dd=-1)),
+        ]
+    )
 
-    gq = q.group_by(['supp_nation', 'cust_nation', 'l_year'])
+    gq = q.group_by(["supp_nation", "cust_nation", "l_year"])
     q = gq.aggregate(revenue=q.volume.sum())
-    q = q.sort_by(['supp_nation', 'cust_nation', 'l_year'])
+    q = q.sort_by(["supp_nation", "cust_nation", "l_year"])
 
     return q

--- a/ibis_tpc/h08.py
+++ b/ibis_tpc/h08.py
@@ -1,22 +1,38 @@
-'National Market Share Query (Q8)'
+"National Market Share Query (Q8)"
 
 import ibis
 
 from .utils import add_date
 
 
-def tpc_h08(con,
-            NATION="BRAZIL",
-            REGION="AMERICA",
-            TYPE="ECONOMY ANODIZED STEEL",
-            DATE='1995-01-01'):
-    part = con.table('part')
-    supplier = con.table('supplier')
-    lineitem = con.table('lineitem')
-    orders = con.table('orders')
-    customer = con.table('customer')
-    region = con.table('region')
-    n1 = con.table('nation')
+def tpc_h08(
+    con,
+    NATION="BRAZIL",
+    REGION="AMERICA",
+    TYPE="ECONOMY ANODIZED STEEL",
+    DATE="1995-01-01",
+):
+    part = con.table("part")
+    supplier = con.table("supplier")
+    lineitem = con.table("lineitem")
+    orders = con.table("orders")
+    customer = con.table("customer")
+    region = con.table("region")
+    n1 = con.table("nation")
+
+    tables = (part, supplier, lineitem, orders, customer, region, n1)
+
+    return _tpc_h08(tables, NATION, REGION, TYPE, DATE)
+
+
+def _tpc_h08(
+    tables,
+    NATION="BRAZIL",
+    REGION="AMERICA",
+    TYPE="ECONOMY ANODIZED STEEL",
+    DATE="1995-01-01",
+):
+    part, supplier, lineitem, orders, customer, region, n1 = tables
     n2 = n1.view()
 
     q = part
@@ -29,22 +45,26 @@ def tpc_h08(con,
     q = q.join(n2, supplier.s_nationkey == n2.n_nationkey)
 
     q = q[
-        orders.o_orderdate.year().cast('string').name('o_year'),
-        (lineitem.l_extendedprice*(1-lineitem.l_discount)).name('volume'),
-        n2.n_name.name('nation'),
+        orders.o_orderdate.year().cast("string").name("o_year"),
+        (lineitem.l_extendedprice * (1 - lineitem.l_discount)).name("volume"),
+        n2.n_name.name("nation"),
         region.r_name,
         orders.o_orderdate,
         part.p_type,
     ]
 
-    q = q.filter([
-        q.r_name == REGION,
-        q.o_orderdate.between(DATE, add_date(DATE, dy=2, dd=-1)),
-        q.p_type == TYPE
-    ])
+    q = q.filter(
+        [
+            q.r_name == REGION,
+            q.o_orderdate.between(DATE, add_date(DATE, dy=2, dd=-1)),
+            q.p_type == TYPE,
+        ]
+    )
 
-    q = q.mutate(nation_volume=ibis.case().when(q.nation == NATION, q.volume).else_(0).end())
+    q = q.mutate(
+        nation_volume=ibis.case().when(q.nation == NATION, q.volume).else_(0).end()
+    )
     gq = q.group_by([q.o_year])
-    q = gq.aggregate(mkt_share=q.nation_volume.sum()/q.volume.sum())
+    q = gq.aggregate(mkt_share=q.nation_volume.sum() / q.volume.sum())
     q = q.sort_by([q.o_year])
     return q

--- a/ibis_tpc/h09.py
+++ b/ibis_tpc/h09.py
@@ -1,33 +1,44 @@
-'Product Type Profit Measure Query (Q9)'
+"Product Type Profit Measure Query (Q9)"
 
 import ibis
 
 
-def tpc_h09(con, COLOR='green'):
-    part = con.table('part')
-    supplier = con.table('supplier')
-    lineitem = con.table('lineitem')
-    partsupp = con.table('partsupp')
-    orders = con.table('orders')
-    nation = con.table('nation')
+def tpc_h09(con, COLOR="green"):
+    part = con.table("part")
+    supplier = con.table("supplier")
+    lineitem = con.table("lineitem")
+    partsupp = con.table("partsupp")
+    orders = con.table("orders")
+    nation = con.table("nation")
 
+    tables = (part, supplier, lineitem, partsupp, orders, nation)
+
+    return _tpc_h09(tables, COLOR)
+
+
+def _tpc_h09(tables, COLOR="green"):
+    part, supplier, lineitem, partsupp, orders, nation = tables
     q = lineitem
     q = q.join(supplier, supplier.s_suppkey == lineitem.l_suppkey)
-    q = q.join(partsupp, (partsupp.ps_suppkey == lineitem.l_suppkey) &
-                         (partsupp.ps_partkey == lineitem.l_partkey))
+    q = q.join(
+        partsupp,
+        (partsupp.ps_suppkey == lineitem.l_suppkey)
+        & (partsupp.ps_partkey == lineitem.l_partkey),
+    )
     q = q.join(part, part.p_partkey == lineitem.l_partkey)
     q = q.join(orders, orders.o_orderkey == lineitem.l_orderkey)
     q = q.join(nation, supplier.s_nationkey == nation.n_nationkey)
-    q = q.materialize()
 
     q = q[
-        (q.l_extendedprice*(1-q.l_discount)-q.ps_supplycost*q.l_quantity).name('amount'),
-        q.o_orderdate.year().cast('string').name('o_year'),
-        q.n_name.name('nation'),
-        q.p_name
+        (q.l_extendedprice * (1 - q.l_discount) - q.ps_supplycost * q.l_quantity).name(
+            "amount"
+        ),
+        q.o_orderdate.year().cast("string").name("o_year"),
+        q.n_name.name("nation"),
+        q.p_name,
     ]
 
-    q = q.filter([q.p_name.like('%'+COLOR+'%')])
+    q = q.filter([q.p_name.like("%" + COLOR + "%")])
 
     gq = q.group_by([q.nation, q.o_year])
     q = gq.aggregate(sum_profit=q.amount.sum())

--- a/ibis_tpc/h10.py
+++ b/ibis_tpc/h10.py
@@ -1,36 +1,45 @@
-'Returned Item Reporting Query (Q10)'
+"Returned Item Reporting Query (Q10)"
 
 import ibis
 from .utils import add_date
 
 
-def tpc_h10(con, DATE='1993-10-01'):
-    customer = con.table('customer')
-    orders = con.table('orders')
-    lineitem = con.table('lineitem')
-    nation = con.table('nation')
+def tpc_h10(con, DATE="1993-10-01"):
+    customer = con.table("customer")
+    orders = con.table("orders")
+    lineitem = con.table("lineitem")
+    nation = con.table("nation")
 
+    tables = (customer, orders, lineitem, nation)
+    return _tpc_h10(tables, DATE)
+
+
+def _tpc_h10(tables, DATE="1993-10-01"):
+    customer, orders, lineitem, nation = tables
     q = customer
     q = q.join(orders, customer.c_custkey == orders.o_custkey)
     q = q.join(lineitem, lineitem.l_orderkey == orders.o_orderkey)
     q = q.join(nation, customer.c_nationkey == nation.n_nationkey)
-    q = q.materialize()
 
-    q = q.filter([
-        (q.o_orderdate >= DATE) & (q.o_orderdate < add_date(DATE, dm=3)),
-        q.l_returnflag == 'R',
-    ])
+    q = q.filter(
+        [
+            (q.o_orderdate >= DATE) & (q.o_orderdate < add_date(DATE, dm=3)),
+            q.l_returnflag == "R",
+        ]
+    )
 
-    gq = q.group_by([
+    gq = q.group_by(
+        [
             q.c_custkey,
             q.c_name,
             q.c_acctbal,
             q.c_phone,
             q.n_name,
             q.c_address,
-            q.c_comment
-    ])
-    q = gq.aggregate(revenue=(q.l_extendedprice*(1-q.l_discount)).sum())
+            q.c_comment,
+        ]
+    )
+    q = gq.aggregate(revenue=(q.l_extendedprice * (1 - q.l_discount)).sum())
 
     q = q.sort_by(ibis.desc(q.revenue))
     return q.limit(20)

--- a/ibis_tpc/h11.py
+++ b/ibis_tpc/h11.py
@@ -1,22 +1,28 @@
 import ibis
 
 
-def tpc_h11(con, NATION='GERMANY', FRACTION=.0001):
-    partsupp = con.table('partsupp')
-    supplier = con.table('supplier')
-    nation = con.table('nation')
+def tpc_h11(con, NATION="GERMANY", FRACTION=0.0001):
+    partsupp = con.table("partsupp")
+    supplier = con.table("supplier")
+    nation = con.table("nation")
+
+    tables = (partsupp, supplier, nation)
+
+    return _tpc_h11(tables, NATION, FRACTION)
+
+
+def _tpc_h11(tables, NATION="GERMANY", FRACTION=0.0001):
+    partsupp, supplier, nation = tables
 
     q = partsupp
     q = q.join(supplier, partsupp.ps_suppkey == supplier.s_suppkey)
     q = q.join(nation, nation.n_nationkey == supplier.s_nationkey)
-    q = q.materialize()
 
     q = q.filter([q.n_name == NATION])
 
     innerq = partsupp
     innerq = innerq.join(supplier, partsupp.ps_suppkey == supplier.s_suppkey)
     innerq = innerq.join(nation, nation.n_nationkey == supplier.s_nationkey)
-    innerq = innerq.materialize()
     innerq = innerq.filter([innerq.n_name == NATION])
     innerq = innerq.aggregate(total=(innerq.ps_supplycost * innerq.ps_availqty).sum())
 

--- a/ibis_tpc/h12.py
+++ b/ibis_tpc/h12.py
@@ -10,9 +10,16 @@ def tpc_h12(con, SHIPMODE1='MAIL', SHIPMODE2='SHIP', DATE='1994-01-01'):
 
     orders = con.table('orders')
     lineitem = con.table('lineitem')
+
+    tables = (orders, lineitem)
+
+    return _tpc_h12(tables, SHIPMODE1, SHIPMODE2, DATE)
+
+
+def _tpc_h12(tables, SHIPMODE1='MAIL', SHIPMODE2='SHIP', DATE='1994-01-01'):
+    orders, lineitem = tables
     q = orders
     q = q.join(lineitem, orders.o_orderkey == lineitem.l_orderkey)
-    q = q.materialize()
 
     q = q.filter([
         q.l_shipmode.isin([SHIPMODE1, SHIPMODE2]),

--- a/ibis_tpc/h13.py
+++ b/ibis_tpc/h13.py
@@ -9,11 +9,18 @@ def tpc_h13(con, WORD1='special', WORD2='requests'):
 
     customer = con.table('customer')
     orders = con.table('orders')
+
+    tables = (customer, orders)
+
+    return _tpc_h13(tables, WORD1, WORD2)
+
+
+def _tpc_h13(tables, WORD1='special', WORD2='requests'):
+    customer, orders = tables
     innerq = customer
     innerq = innerq.left_join(orders, (
                 customer.c_custkey == orders.o_custkey) &
                 ~orders.o_comment.like(f'%{WORD1}%{WORD2}%'))
-    innerq = innerq.materialize()
     innergq = innerq.group_by([innerq.c_custkey])
     innerq = innergq.aggregate(c_count=innerq.o_orderkey.count())
 

--- a/ibis_tpc/h14.py
+++ b/ibis_tpc/h14.py
@@ -1,24 +1,28 @@
 from .utils import add_date
 
 
-def tpc_h14(con, DATE='1995-09-01'):
-    '''Promotion Effect Query (Q14)
+def tpc_h14(con, DATE="1995-09-01"):
+    """Promotion Effect Query (Q14)
 
-       This query monitors the market response to a promotion such as TV
-       advertisements or a special campaign.'''
+    This query monitors the market response to a promotion such as TV
+    advertisements or a special campaign."""
 
-    lineitem = con.table('lineitem')
-    part = con.table('part')
+    lineitem = con.table("lineitem")
+    part = con.table("part")
+
+    tables = (lineitem, part)
+
+    return _tpc_h14(tables, DATE)
+
+
+def _tpc_h14(tables, DATE="1995-09-01"):
+    lineitem, part = tables
     q = lineitem
     q = q.join(part, lineitem.l_partkey == part.p_partkey)
-    q = q.materialize()
-    q = q.filter([
-        q.l_shipdate >= DATE,
-        q.l_shipdate < add_date(DATE, dm=1)
-    ])
+    q = q.filter([q.l_shipdate >= DATE, q.l_shipdate < add_date(DATE, dm=1)])
 
-    revenue = q.l_extendedprice*(1-q.l_discount)
-    promo_revenue = q.p_type.like('promo%').ifelse(revenue, 0)
+    revenue = q.l_extendedprice * (1 - q.l_discount)
+    promo_revenue = q.p_type.like("promo%").ifelse(revenue, 0)
 
-    q = q.aggregate(promo_revenue=100*promo_revenue.sum()/revenue.sum())
+    q = q.aggregate(promo_revenue=100 * promo_revenue.sum() / revenue.sum())
     return q

--- a/ibis_tpc/h15.py
+++ b/ibis_tpc/h15.py
@@ -1,32 +1,31 @@
 from .utils import add_date
 
 
-def tpc_h15(con, DATE='1996-01-01'):
-    'Top Supplier Query (Q15)'
+def tpc_h15(con, DATE="1996-01-01"):
+    "Top Supplier Query (Q15)"
 
-    lineitem = con.table('lineitem')
-    supplier = con.table('supplier')
+    lineitem = con.table("lineitem")
+    supplier = con.table("supplier")
+
+    tables = (lineitem, supplier)
+    return _tpc_h15(tables, DATE)
+
+
+def _tpc_h15(tables, DATE="1996-01-01"):
+    lineitem, supplier = tables
 
     qrev = lineitem
-    qrev = qrev.filter([
-        lineitem.l_shipdate >= DATE,
-        lineitem.l_shipdate < add_date(DATE, dm=3)
-    ])
+    qrev = qrev.filter(
+        [lineitem.l_shipdate >= DATE, lineitem.l_shipdate < add_date(DATE, dm=3)]
+    )
 
     gqrev = qrev.group_by([lineitem.l_suppkey])
-    qrev = gqrev.aggregate(total_revenue=(qrev.l_extendedprice*(1-qrev.l_discount)).sum())
+    qrev = gqrev.aggregate(
+        total_revenue=(qrev.l_extendedprice * (1 - qrev.l_discount)).sum()
+    )
 
     q = supplier.join(qrev, supplier.s_suppkey == qrev.l_suppkey)
-    q = q.materialize()
-    q = q.filter([
-        q.total_revenue == qrev.total_revenue.max()
-    ])
+    q = q.filter([q.total_revenue == qrev.total_revenue.max()])
     q = q.sort_by([q.s_suppkey])
-    q = q[
-        q.s_suppkey,
-        q.s_name,
-        q.s_address,
-        q.s_phone,
-        q.total_revenue
-    ]
+    q = q[q.s_suppkey, q.s_name, q.s_address, q.s_phone, q.total_revenue]
     return q

--- a/ibis_tpc/h16.py
+++ b/ibis_tpc/h16.py
@@ -4,26 +4,46 @@ import ibis
 ibis.options.sql.default_limit = 100000
 
 
-def tpc_h16(con, BRAND='Brand#45', TYPE='MEDIUM POLISHED',
-            SIZES=(49, 14, 23, 45, 19, 3, 36, 9)):
-    '''Parts/Supplier Relationship Query (Q16)
+def tpc_h16(
+    con,
+    BRAND="Brand#45",
+    TYPE="MEDIUM POLISHED",
+    SIZES=(49, 14, 23, 45, 19, 3, 36, 9),
+):
+    """Parts/Supplier Relationship Query (Q16)
 
-       This query finds out how many suppliers can supply parts with given
-       attributes. It might be used, for example, to determine whether there is
-       a sufficient number of suppliers for heavily ordered parts.'''
+    This query finds out how many suppliers can supply parts with given
+    attributes. It might be used, for example, to determine whether there is
+    a sufficient number of suppliers for heavily ordered parts."""
 
-    partsupp = con.table('partsupp')
-    part = con.table('part')
-    supplier = con.table('supplier')
+    partsupp = con.table("partsupp")
+    part = con.table("part")
+    supplier = con.table("supplier")
 
+    tables = (partsupp, part, supplier)
+    return _tpc_h16(tables, BRAND, TYPE)
+
+
+def _tpc_h16(
+    tables,
+    BRAND="Brand#45",
+    TYPE="MEDIUM POLISHED",
+    SIZES=(49, 14, 23, 45, 19, 3, 36, 9),
+):
+    partsupp, part, supplier = tables
     q = partsupp.join(part, part.p_partkey == partsupp.ps_partkey)
-    q = q.materialize()
-    q = q.filter([
-        q.p_brand != BRAND,
-        ~q.p_type.like(f'{TYPE}%'),
-        q.p_size.isin(SIZES),
-        ~q.ps_suppkey.isin(supplier.filter([supplier.s_comment.like('%customer%complaints%')]).s_suppkey)
-    ])
+    q = q.filter(
+        [
+            q.p_brand != BRAND,
+            ~q.p_type.like(f"{TYPE}%"),
+            q.p_size.isin(SIZES),
+            ~q.ps_suppkey.isin(
+                supplier.filter(
+                    [supplier.s_comment.like("%customer%complaints%")]
+                ).s_suppkey
+            ),
+        ]
+    )
     gq = q.groupby([q.p_brand, q.p_type, q.p_size])
     q = gq.aggregate(supplier_cnt=q.ps_suppkey.nunique())
     q = q.sort_by([ibis.desc(q.supplier_cnt), q.p_brand, q.p_type, q.p_size])

--- a/ibis_tpc/h17.py
+++ b/ibis_tpc/h17.py
@@ -1,24 +1,30 @@
-
-def tpc_h17(con, BRAND='Brand#23', CONTAINER='MED BOX'):
-    '''Small-Quantity-Order Revenue Query (Q17)
+def tpc_h17(con, BRAND="Brand#23", CONTAINER="MED BOX"):
+    """Small-Quantity-Order Revenue Query (Q17)
 
     This query determines how much average yearly revenue would be lost if
     orders were no longer filled for small quantities of certain parts. This
-    may reduce overhead expenses by concentrating sales on larger shipments.'''
+    may reduce overhead expenses by concentrating sales on larger shipments."""
 
-    lineitem = con.table('lineitem')
-    part = con.table('part')
+    lineitem = con.table("lineitem")
+    part = con.table("part")
 
+    tables = (lineitem, part)
+    return _tpc_h17(tables, BRAND, CONTAINER)
+
+
+def _tpc_h17(tables, BRAND="Brand#23", CONTAINER="MED BOX"):
+    lineitem, part = tables
     q = lineitem.join(part, part.p_partkey == lineitem.l_partkey)
-    q = q.materialize()
 
     innerq = lineitem
     innerq = innerq.filter([innerq.l_partkey == q.p_partkey])
 
-    q = q.filter([
-        q.p_brand == BRAND,
-        q.p_container == CONTAINER,
-        q.l_quantity < (0.2*innerq.l_quantity.mean())
-    ])
-    q = q.aggregate(avg_yearly=q.l_extendedprice.sum()/7.0)
+    q = q.filter(
+        [
+            q.p_brand == BRAND,
+            q.p_container == CONTAINER,
+            q.l_quantity < (0.2 * innerq.l_quantity.mean()),
+        ]
+    )
+    q = q.aggregate(avg_yearly=q.l_extendedprice.sum() / 7.0)
     return q

--- a/ibis_tpc/h18.py
+++ b/ibis_tpc/h18.py
@@ -2,16 +2,22 @@ import ibis
 
 
 def tpc_h18(con, QUANTITY=300):
-    '''Large Volume Customer Query (Q18)
+    """Large Volume Customer Query (Q18)
 
     The Large Volume Customer Query ranks customers based on their having
     placed a large quantity order. Large quantity orders are defined as those
-    orders whose total quantity is above a certain level.'''
+    orders whose total quantity is above a certain level."""
 
-    customer = con.table('customer')
-    orders = con.table('orders')
-    lineitem = con.table('lineitem')
+    customer = con.table("customer")
+    orders = con.table("orders")
+    lineitem = con.table("lineitem")
 
+    tables = (customer, orders, lineitem)
+    return _tpc_h18(tables, QUANTITY)
+
+
+def _tpc_h18(tables, QUANTITY=300):
+    customer, orders, lineitem = tables
     subgq = lineitem.groupby([lineitem.l_orderkey])
     subq = subgq.aggregate(qty_sum=lineitem.l_quantity.sum())
     subq = subq.filter([subq.qty_sum > QUANTITY])
@@ -19,10 +25,7 @@ def tpc_h18(con, QUANTITY=300):
     q = customer
     q = q.join(orders, customer.c_custkey == orders.o_custkey)
     q = q.join(lineitem, orders.o_orderkey == lineitem.l_orderkey)
-    q = q.materialize()
-    q = q.filter([
-        q.o_orderkey.isin(subq.l_orderkey)
-    ])
+    q = q.filter([q.o_orderkey.isin(subq.l_orderkey)])
 
     gq = q.groupby([q.c_name, q.c_custkey, q.o_orderkey, q.o_orderdate, q.o_totalprice])
     q = gq.aggregate(sum_qty=q.l_quantity.sum())

--- a/ibis_tpc/h19.py
+++ b/ibis_tpc/h19.py
@@ -1,42 +1,68 @@
-
-def tpc_h19(con, QUANTITY1=1, QUANTITY2=10, QUANTITY3=20,
-            BRAND1='Brand#12', BRAND2='Brand#23', BRAND3='Brand#34'):
-    '''Discounted Revenue Query (Q19)
+def tpc_h19(
+    con,
+    QUANTITY1=1,
+    QUANTITY2=10,
+    QUANTITY3=20,
+    BRAND1="Brand#12",
+    BRAND2="Brand#23",
+    BRAND3="Brand#34",
+):
+    """Discounted Revenue Query (Q19)
 
     The Discounted Revenue Query reports the gross discounted revenue
     attributed to the sale of selected parts handled in a particular manner.
     This query is an example of code such as might be produced programmatically
-    by a data mining tool.'''
+    by a data mining tool."""
 
-    lineitem = con.table('lineitem')
-    part = con.table('part')
+    lineitem = con.table("lineitem")
+    part = con.table("part")
+
+    tables = (lineitem, part)
+    return _tpc_h19(tables, QUANTITY1, QUANTITY2, QUANTITY3, BRAND1, BRAND2, BRAND3)
+
+
+def _tpc_h19(
+    tables,
+    QUANTITY1=1,
+    QUANTITY2=10,
+    QUANTITY3=20,
+    BRAND1="Brand#12",
+    BRAND2="Brand#23",
+    BRAND3="Brand#34",
+):
+    lineitem, part = tables
     q = lineitem.join(part, part.p_partkey == lineitem.l_partkey)
-    q = q.materialize()
 
-    q1 = ((q.p_brand == BRAND1) &
-          (q.p_container.isin(('sm case', 'sm box', 'sm pack', 'sm pkg'))) &
-          (q.l_quantity >= QUANTITY1) &
-          (q.l_quantity <= QUANTITY1 + 10) &
-          (q.p_size.between(1, 5)) &
-          (q.l_shipmode.isin(('air', 'air reg'))) &
-          (q.l_shipinstruct == 'deliver in person'))
+    q1 = (
+        (q.p_brand == BRAND1)
+        & (q.p_container.isin(("sm case", "sm box", "sm pack", "sm pkg")))
+        & (q.l_quantity >= QUANTITY1)
+        & (q.l_quantity <= QUANTITY1 + 10)
+        & (q.p_size.between(1, 5))
+        & (q.l_shipmode.isin(("air", "air reg")))
+        & (q.l_shipinstruct == "deliver in person")
+    )
 
-    q2 = ((q.p_brand == BRAND2) &
-          (q.p_container.isin(('med bag', 'med box', 'med pkg', 'med pack'))) &
-          (q.l_quantity >= QUANTITY2) &
-          (q.l_quantity <= QUANTITY2 + 10) &
-          (q.p_size.between(1, 10)) &
-          (q.l_shipmode.isin(('air', 'air reg'))) &
-          (q.l_shipinstruct == 'deliver in person'))
+    q2 = (
+        (q.p_brand == BRAND2)
+        & (q.p_container.isin(("med bag", "med box", "med pkg", "med pack")))
+        & (q.l_quantity >= QUANTITY2)
+        & (q.l_quantity <= QUANTITY2 + 10)
+        & (q.p_size.between(1, 10))
+        & (q.l_shipmode.isin(("air", "air reg")))
+        & (q.l_shipinstruct == "deliver in person")
+    )
 
-    q3 = ((q.p_brand == BRAND3) &
-          (q.p_container.isin(('lg case', 'lg box', 'lg pack', 'lg pkg'))) &
-          (q.l_quantity >= QUANTITY3) &
-          (q.l_quantity <= QUANTITY3 + 10) &
-          (q.p_size.between(1, 15)) &
-          (q.l_shipmode.isin(('air', 'air reg'))) &
-          (q.l_shipinstruct == 'deliver in person'))
+    q3 = (
+        (q.p_brand == BRAND3)
+        & (q.p_container.isin(("lg case", "lg box", "lg pack", "lg pkg")))
+        & (q.l_quantity >= QUANTITY3)
+        & (q.l_quantity <= QUANTITY3 + 10)
+        & (q.p_size.between(1, 15))
+        & (q.l_shipmode.isin(("air", "air reg")))
+        & (q.l_shipinstruct == "deliver in person")
+    )
 
     q = q.filter([q1 | q2 | q3])
-    q = q.aggregate(revenue=(q.l_extendedprice*(1-q.l_discount)).sum())
+    q = q.aggregate(revenue=(q.l_extendedprice * (1 - q.l_discount)).sum())
     return q

--- a/ibis_tpc/h20.py
+++ b/ibis_tpc/h20.py
@@ -1,41 +1,48 @@
 from .utils import add_date
 
 
-def tpc_h20(con, COLOR='forest', DATE='1994-01-01', NATION='CANADA'):
-    '''Potential Part Promotion Query (Q20)
+def tpc_h20(con, COLOR="forest", DATE="1994-01-01", NATION="CANADA"):
+    """Potential Part Promotion Query (Q20)
 
     The Potential Part Promotion Query identifies suppliers in a particular
     nation having selected parts that may be candidates for a promotional
-    offer.'''
+    offer."""
 
-    supplier = con.table('supplier')
-    nation = con.table('nation')
-    partsupp = con.table('partsupp')
-    part = con.table('part')
-    lineitem = con.table('lineitem')
+    supplier = con.table("supplier")
+    nation = con.table("nation")
+    partsupp = con.table("partsupp")
+    part = con.table("part")
+    lineitem = con.table("lineitem")
+
+    tables = (supplier, nation, partsupp, part, lineitem)
+    return _tpc_h20(tables, COLOR, DATE, NATION)
+
+
+def _tpc_h20(tables, COLOR="forest", DATE="1994-01-01", NATION="CANADA"):
+    supplier, nation, partsupp, part, lineitem = tables
 
     q1 = supplier.join(nation, supplier.s_nationkey == nation.n_nationkey)
-    q1 = q1.materialize()
 
-    q3 = part.filter([part.p_name.like(f'{COLOR}%')])
+    q3 = part.filter([part.p_name.like(f"{COLOR}%")])
     q2 = partsupp
 
-    q4 = lineitem.filter([
-        lineitem.l_partkey == q2.ps_partkey,
-        lineitem.l_suppkey == q2.ps_suppkey,
-        lineitem.l_shipdate >= DATE,
-        lineitem.l_shipdate < add_date(DATE, dy=1),
-    ])
+    q4 = lineitem.filter(
+        [
+            lineitem.l_partkey == q2.ps_partkey,
+            lineitem.l_suppkey == q2.ps_suppkey,
+            lineitem.l_shipdate >= DATE,
+            lineitem.l_shipdate < add_date(DATE, dy=1),
+        ]
+    )
 
-    q2 = q2.filter([
-        partsupp.ps_partkey.isin(q3.p_partkey),
-        partsupp.ps_availqty > .5*q4.l_quantity.sum()
-    ])
+    q2 = q2.filter(
+        [
+            partsupp.ps_partkey.isin(q3.p_partkey),
+            partsupp.ps_availqty > 0.5 * q4.l_quantity.sum(),
+        ]
+    )
 
-    q1 = q1.filter([
-        q1.n_name == NATION,
-        q1.s_suppkey.isin(q2.ps_suppkey)
-    ])
+    q1 = q1.filter([q1.n_name == NATION, q1.s_suppkey.isin(q2.ps_suppkey)])
 
     q1 = q1[q1.s_name, q1.s_address]
 

--- a/ibis_tpc/h22.py
+++ b/ibis_tpc/h22.py
@@ -1,30 +1,39 @@
-def tpc_h22(con, COUNTRY_CODES=('13', '31', '23', '29', '30', '18', '17')):
-    '''Global Sales Opportunity Query (Q22)
+def tpc_h22(con, COUNTRY_CODES=("13", "31", "23", "29", "30", "18", "17")):
+    """Global Sales Opportunity Query (Q22)
 
     The Global Sales Opportunity Query identifies geographies where there are
-    customers who may be likely to make a purchase.'''
+    customers who may be likely to make a purchase."""
 
-    customer = con.table('customer')
-    orders = con.table('orders')
+    customer = con.table("customer")
+    orders = con.table("orders")
 
-    q = customer.filter([
-        customer.c_acctbal > 0.00,
-        customer.c_phone.substr(0, 2).isin(COUNTRY_CODES),
-    ])
+    tables = (customer, orders)
+    return _tpc_h22(tables, COUNTRY_CODES)
+
+
+def _tpc_h22(tables, COUNTRY_CODES=("13", "31", "23", "29", "30", "18", "17")):
+    customer, orders = tables
+
+    q = customer.filter(
+        [
+            customer.c_acctbal > 0.00,
+            customer.c_phone.substr(0, 2).isin(COUNTRY_CODES),
+        ]
+    )
     q = q.aggregate(avg_bal=customer.c_acctbal.mean())
 
-    custsale = customer.filter([
-        customer.c_phone.substr(0, 2).isin(COUNTRY_CODES),
-        customer.c_acctbal > q.avg_bal,
-        ~(orders.o_custkey == customer.c_custkey).any()
-    ])
+    custsale = customer.filter(
+        [
+            customer.c_phone.substr(0, 2).isin(COUNTRY_CODES),
+            customer.c_acctbal > q.avg_bal,
+            ~(orders.o_custkey == customer.c_custkey).any(),
+        ]
+    )
     custsale = custsale[
-        customer.c_phone.substr(0, 2).name('cntrycode'),
-        customer.c_acctbal
+        customer.c_phone.substr(0, 2).name("cntrycode"), customer.c_acctbal
     ]
 
     gq = custsale.group_by(custsale.cntrycode)
-    outerq = gq.aggregate(numcust=custsale.count(),
-                          totacctbal=custsale.c_acctbal.sum())
+    outerq = gq.aggregate(numcust=custsale.count(), totacctbal=custsale.c_acctbal.sum())
 
     return outerq.sort_by(outerq.cntrycode)

--- a/ibis_tpc/runners.py
+++ b/ibis_tpc/runners.py
@@ -106,6 +106,25 @@ class SqliteRunner(Runner):
                     sqlite_version=sqlite3.sqlite_version)
 
 
+class DuckDBRunner(Runner):
+    def setup(self, db='tpch.ddb'):
+        super().setup(db=db)
+        import duckdb
+
+        self.con = duckdb.connect(db)
+
+    def run(self, qid, outdir=None, backend='duckdb'):
+        cur = self.con.cursor()
+
+        sql = open(f'duckdb_tpc/{qid}.sql').read()
+        t1 = time.time()
+        cur.execute(sql)
+        rows = cur.fetch_df()
+        t2 = time.time()
+        rows = rows.to_dict('records')
+        return rows, t2-t1
+
+
 class IbisRunner(Runner):
     def setup(self, db='tpch.db'):
         super().setup(db=db)
@@ -219,6 +238,7 @@ class RRunner(Runner):
 setup_sqlite = SqliteRunner
 setup_ibis = IbisRunner
 setup_sqlalchemy = SqlAlchemyRunner
+setup_duckdb = DuckDBRunner
 setup_dplyr = RRunner
 setup_dbplyr = RRunner
 

--- a/ibis_tpc/runners.py
+++ b/ibis_tpc/runners.py
@@ -241,8 +241,13 @@ def compare(rows1, rows2):
         for k in keys:
             v1 = lcr1.get(k, None)
             v2 = lcr2.get(k, None)
-            if isinstance(v2, pandas.Timestamp):
-                if v1 != v2.strftime('%Y-%m-%d'):
+            if any(map(lambda x: isinstance(x, pandas.Timestamp), (v1, v2))):
+                v1, v2 = map(
+                    lambda x:
+                    x.strftime('%Y-%m-%d')
+                    if isinstance(x, pandas.Timestamp)
+                    else x, (v1, v2))
+                if v1 != v2:
                     diffs.append(f'[{i}].{k} (date) {v1} != {v2}')
             elif isinstance(v1, float) and isinstance(v2, float):
                 if v2 != v1:

--- a/ibis_tpc/tests/conftest.py
+++ b/ibis_tpc/tests/conftest.py
@@ -1,0 +1,91 @@
+import duckdb
+import ibis
+import pytest
+from ibis.backends.duckdb.parser import parse_type
+from ibis_substrait.compiler.core import SubstraitCompiler
+
+
+def unbound_from_duckdb(table):
+    return ibis.table(
+        list(zip(table.columns, map(parse_type, table.dtypes))), name=table.alias
+    )
+
+
+@pytest.fixture(scope="module")
+def con():
+    yield duckdb.connect("tpch.ddb")
+
+
+@pytest.fixture(scope="module")
+def compiler():
+    yield SubstraitCompiler()
+
+
+@pytest.fixture(scope="module")
+def part(con):
+    table = con.table("part")
+    yield unbound_from_duckdb(table)
+
+
+@pytest.fixture(scope="module")
+def supplier(con):
+    table = con.table("supplier")
+    yield unbound_from_duckdb(table)
+
+
+@pytest.fixture(scope="module")
+def partsupp(con):
+    table = con.table("partsupp")
+    yield unbound_from_duckdb(table)
+
+
+@pytest.fixture(scope="module")
+def nation(con):
+    table = con.table("nation")
+    yield unbound_from_duckdb(table)
+
+
+@pytest.fixture(scope="module")
+def region(con):
+    table = con.table("region")
+    yield unbound_from_duckdb(table)
+
+
+@pytest.fixture(scope="module")
+def lineitem(con):
+    table = con.table("lineitem")
+    yield unbound_from_duckdb(table)
+
+
+@pytest.fixture(scope="module")
+def customer(con):
+    table = con.table("customer")
+    yield unbound_from_duckdb(table)
+
+
+@pytest.fixture(scope="module")
+def orders(con):
+    table = con.table("orders")
+    yield unbound_from_duckdb(table)
+
+
+def pytest_runtest_call(item):
+    """Dynamically add various custom markers."""
+    #nodeid = item.nodeid
+
+    for marker in item.iter_markers(name="duckdb_internal_error"):
+        item.add_marker(
+            pytest.mark.xfail(reason="DuckDB Internal Error")
+            )
+    for marker in item.iter_markers(name="corr_sub_query"):
+        item.add_marker(
+            pytest.mark.xfail(reason="Substrait doesn't support correlated subqueries")
+            )
+    for marker in item.iter_markers(name="duckdb_catalog_error"):
+        item.add_marker(
+            pytest.mark.xfail(reason="DuckDB Catalog Error")
+            )
+    for marker in item.iter_markers(name="ibis_substrait_error"):
+        item.add_marker(
+            pytest.mark.xfail(reason="Ibis substrait compilation failure")
+            )

--- a/ibis_tpc/tests/test_substrait.py
+++ b/ibis_tpc/tests/test_substrait.py
@@ -1,0 +1,154 @@
+import importlib
+from datetime import date
+
+import ibis_tpc
+import pytest
+
+
+modules = list(map(lambda x: f"ibis_tpc.h{x:02d}", range(1, 23)))
+
+for module in modules:
+    importlib.import_module(module)
+
+test_params = [
+    pytest.param(
+        ibis_tpc.h01._tpc_h01,
+        ("lineitem",),
+        {"DATE": date(1998, 12, 1)},
+        marks=[pytest.mark.duckdb_internal_error],
+    ),
+    pytest.param(
+        ibis_tpc.h02._tpc_h02,
+        ("part", "supplier", "partsupp", "nation", "region"),
+        {},
+        marks=[pytest.mark.corr_sub_query],
+    ),
+    pytest.param(
+        ibis_tpc.h03._tpc_h03,
+        ("customer", "orders", "lineitem"),
+        {"DATE": date(1995, 3, 15)},
+        marks=[pytest.mark.duckdb_internal_error],
+    ),
+    pytest.param(
+        ibis_tpc.h04._tpc_h04,
+        ("orders", "lineitem"),
+        {"DATE": date(1993, 7, 1)},
+        marks=[pytest.mark.duckdb_internal_error],
+    ),
+    pytest.param(
+        ibis_tpc.h05._tpc_h05,
+        ("customer", "orders", "lineitem", "supplier", "nation", "region"),
+        {"DATE": date(1994, 1, 1)},
+        marks=[pytest.mark.duckdb_internal_error],
+    ),
+    pytest.param(
+        ibis_tpc.h06._tpc_h06,
+        ("lineitem",),
+        {"DATE": date(1994, 1, 1)},
+        marks=[pytest.mark.duckdb_internal_error],
+    ),
+    pytest.param(
+        ibis_tpc.h07._tpc_h07,
+        ("supplier", "lineitem", "orders", "customer", "nation"),
+        {"DATE": date(1995, 1, 1)},
+        marks=[pytest.mark.corr_sub_query],
+    ),
+    pytest.param(
+        ibis_tpc.h08._tpc_h08,
+        ("part", "supplier", "lineitem", "orders", "customer", "region", "nation"),
+        {"DATE": date(1995, 1, 1)},
+        marks=[pytest.mark.corr_sub_query],
+    ),
+    pytest.param(
+        ibis_tpc.h09._tpc_h09,
+        ("part", "supplier", "lineitem", "partsupp", "orders", "nation"),
+        {},
+        marks=[pytest.mark.duckdb_internal_error],
+    ),
+    pytest.param(
+        ibis_tpc.h10._tpc_h10,
+        ("customer", "orders", "lineitem", "nation"),
+        {"DATE": date(1993, 10, 1)},
+        marks=[pytest.mark.duckdb_internal_error],
+    ),
+    pytest.param(
+        ibis_tpc.h11._tpc_h11,
+        ("partsupp", "supplier", "nation"),
+        {},
+        marks=[pytest.mark.duckdb_catalog_error],
+    ),
+    pytest.param(
+        ibis_tpc.h12._tpc_h12,
+        ("orders", "lineitem"),
+        {"DATE": date(1994, 1, 1)},
+        marks=[pytest.mark.duckdb_internal_error],
+    ),
+    pytest.param(
+        ibis_tpc.h13._tpc_h13,
+        ("customer", "orders"),
+        {},
+        marks=[pytest.mark.duckdb_catalog_error],
+    ),
+    pytest.param(
+        ibis_tpc.h14._tpc_h14,
+        ("lineitem", "part"),
+        {"DATE": date(1995, 9, 1)},
+        marks=[pytest.mark.corr_sub_query],
+    ),
+    pytest.param(
+        ibis_tpc.h15._tpc_h15,
+        ("lineitem", "supplier"),
+        {"DATE": date(1996, 1, 1)},
+        marks=[pytest.mark.ibis_substrait_error],
+    ),
+    pytest.param(
+        ibis_tpc.h16._tpc_h16,
+        ("partsupp", "part", "supplier"),
+        {},
+        marks=[pytest.mark.duckdb_internal_error],
+    ),
+    pytest.param(
+        ibis_tpc.h17._tpc_h17,
+        ("lineitem", "part"),
+        {},
+        marks=[pytest.mark.corr_sub_query],
+    ),
+    pytest.param(
+        ibis_tpc.h18._tpc_h18,
+        ("customer", "orders", "lineitem"),
+        {},
+        marks=[pytest.mark.duckdb_internal_error],
+    ),
+    pytest.param(
+        ibis_tpc.h19._tpc_h19,
+        ("lineitem", "part"),
+        {},
+        marks=[pytest.mark.duckdb_internal_error],
+    ),
+    pytest.param(
+        ibis_tpc.h20._tpc_h20,
+        ("supplier", "nation", "partsupp", "part", "lineitem"),
+        {"DATE": date(1994, 1, 1)},
+        marks=[pytest.mark.duckdb_catalog_error],
+    ),
+    pytest.param(
+        ibis_tpc.h21._tpc_h21,
+        ("supplier", "lineitem", "orders", "nation"),
+        {},
+        marks=[pytest.mark.duckdb_catalog_error],
+    ),
+    pytest.param(
+        ibis_tpc.h22._tpc_h22,
+        ("customer", "orders"),
+        {},
+        marks=[pytest.mark.duckdb_internal_error],
+    ),
+]
+
+
+@pytest.mark.parametrize("func, tables, dates", test_params)
+def test_tpc(con, compiler, func, tables, dates, request):
+    tables = list(map(request.getfixturevalue, tables))
+    query = func(tables, **dates)
+    proto = compiler.compile(query)
+    con.from_substrait(proto.SerializeToString())

--- a/ibis_tpc/utils.py
+++ b/ibis_tpc/utils.py
@@ -1,12 +1,25 @@
 import datetime
+import functools
 
 
+@functools.singledispatch
 def add_date(datestr, dy=0, dm=0, dd=0):
     dt = datetime.date.fromisoformat(datestr)
-    m = dt.month+dm
-    y = dt.year+dy
+    m = dt.month + dm
+    y = dt.year + dy
     y += m // 12
-    m = ((m-1) % 12) + 1
+    m = ((m - 1) % 12) + 1
 
     newdt = datetime.date(y, m, dt.day) + datetime.timedelta(days=dd)
     return newdt.isoformat()
+
+
+@add_date.register(datetime.date)
+def _(dt, dy=0, dm=0, dd=0):
+    m = dt.month + dm
+    y = dt.year + dy
+    y += m // 12
+    m = ((m - 1) % 12) + 1
+
+    newdt = datetime.date(y, m, dt.day) + datetime.timedelta(days=dd)
+    return newdt

--- a/ibis_tpc/utils.py
+++ b/ibis_tpc/utils.py
@@ -1,25 +1,16 @@
 import datetime
 import functools
+from dateutil.relativedelta import relativedelta
 
 
 @functools.singledispatch
 def add_date(datestr, dy=0, dm=0, dd=0):
     dt = datetime.date.fromisoformat(datestr)
-    m = dt.month + dm
-    y = dt.year + dy
-    y += m // 12
-    m = ((m - 1) % 12) + 1
-
-    newdt = datetime.date(y, m, dt.day) + datetime.timedelta(days=dd)
-    return newdt.isoformat()
+    dt += relativedelta(years=dy, months=dm, days=dd)
+    return dt.isoformat()
 
 
 @add_date.register(datetime.date)
 def _(dt, dy=0, dm=0, dd=0):
-    m = dt.month + dm
-    y = dt.year + dy
-    y += m // 12
-    m = ((m - 1) % 12) + 1
-
-    newdt = datetime.date(y, m, dt.day) + datetime.timedelta(days=dd)
-    return newdt
+    dt += relativedelta(years=dy, months=dm, days=dd)
+    return dt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.pytest.ini_options]
+xfail_strict = true
+addopts = [
+  "--ignore=site-packages",
+  "--ignore=dist-packages",
+  "--strict-markers",
+  "--strict-config",
+  "--benchmark-skip",
+  "--randomly-dont-reorganize"
+]
+empty_parameter_set_mark = "fail_at_collect"
+norecursedirs = ["site-packages", "dist-packages"]
+markers = [
+  "duckdb_internal_error: Query throws a duckdb internal error",
+  "corr_sub_query: Query fails because no support for correlated subqueries in substrait",
+  "duckdb_catalog_error: Query fails because of a duckdb catalog error",
+  "ibis_substrait_error: Query fails because of a substrait compilation failure"
+  ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 rpy2
 click
 pandas
+python-dateutil
 ibis-framework[sqlite]
 sqlparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pandas
 python-dateutil
 ibis-framework[sqlite]
 sqlparse
+duckdb
+duckdb-engine


### PR DESCRIPTION
This got bigger than I expected.  It does a few things:

1. Removes all usage of `materialize` (with eyes towards the release of Ibis 3.x)
2. Adds one level of abstraction around the Ibis query functions so that it is possible to pass in a set of tables directly, instead of a connection.  This allows for creating and passing in unbound Ibis tables with an eye towards...
3. Adding in ibis-substrait to compile and then serialize the queries to protobuf, before then...
4. Attempting to deserialize and execute them using DuckDB.

Currently, all 22 queries are failing :raised_eyebrow

Two of the failure modes in DuckDB look like they probably aren't too hard to fix?  Those are the "single grouping sets" not supported error, and the Catalog Errors, which look like they probably just need a lookup table?

I haven't yet dug in to the nature of the `INTERNAL Error` messages.

| Query | Error                                                                                                                              | Substrait or DuckDB |
|-------|------------------------------------------------------------------------------------------------------------------------------------|---------------------|
| h01   | RuntimeError: INTERNAL Error: Only single grouping sets are supported for now                                                      | DuckDB              |
| h02   | TypeError: Parameter to MergeFrom() must be instance of same class: expected substrait.Expression got substrait.AggregateFunction. | Substrait           |
| h03   | RuntimeError: INTERNAL Error: Only single grouping sets are supported for now                                                      | DuckDB              |
| h04   | RuntimeError: INTERNAL Error: 16                                                                                                   | DuckDB              |
| h05   | RuntimeError: INTERNAL Error: 2                                                                                                    | DuckDB              |
| h06   | RuntimeError: INTERNAL Error: 16                                                                                                   | DuckDB              |
| h07   | NotImplementedError: (SelfReference(UnboundTable\[r0, name=nation\]                                                                | Substrait           |
| h08   | NotImplementedError: (SelfReference(UnboundTable\[r0, name=nation\]                                                                | Substrait           |
| h09   | RuntimeError: INTERNAL Error: Only single grouping sets are supported for now                                                      | DuckDB              |
| h10   | RuntimeError: INTERNAL Error: Only single grouping sets are supported for now                                                      | DuckDB              |
| h11   | RuntimeError: Catalog Error: Scalar Function with name equals does not exist!                                                      | DuckDB              |
| h12   | RuntimeError: INTERNAL Error: 2                                                                                                    | DuckDB              |
| h13   | RuntimeError: Catalog Error: Scalar Function with name equals does not exist!                                                      | DuckDB              |
| h14   | TypeError: Parameter to MergeFrom() must be instance of same class: expected substrait.Expression got substrait.AggregateFunction. | Substrait           |
| h15   | AssertionError: non-empty child<sub>relfieldoffsets</sub> passed in to selection translation rule                                  | Substrait           |
| h16   | RuntimeError: INTERNAL Error: Only single grouping sets are supported for now                                                      | DuckDB              |
| h17   | TypeError: Parameter to MergeFrom() must be instance of same class: expected substrait.Expression got substrait.AggregateFunction. | Substrait           |
| h18   | RuntimeError: INTERNAL Error: Only single grouping sets are supported for now                                                      | DuckDB              |
| h19   | RuntimeError: INTERNAL Error: 2                                                                                                    | DuckDB              |
| h20   | RuntimeError: Catalog Error: Scalar Function with name equals does not exist!                                                      | DuckDB              |
| h21   | RuntimeError: Catalog Error: Scalar Function with name equals does not exist!                                                      | DuckDB              |
| h22   | RuntimeError: INTERNAL Error: 2                                                                                                    | DuckDB              |

Leaving this as a draft for the moment -- need to figure out if we want to add `xfail` to all of the TPC tests so we can get a read on when they start working (also this currently needs to run against a _very_ fresh DuckDB master since the `get_substrait` and `from_substrait` PR was only merged on Friday 2022/03/18
