### PR TITLE
chore: use pyarrow>=9.0.0 to support proper timestamps and decimals

### DIFF
--- a/ibis_tpc/runners.py
+++ b/ibis_tpc/runners.py
@@ -131,7 +131,7 @@ class DuckDBRunner(Runner):
         sql = open(f"sqlite_tpc/{qid}.sql").read()
         t1 = time.time()
         cur.execute(sql)
-        rows = cur.fetch_df()
+        rows = cur.fetch_arrow_table().to_pandas()
         t2 = time.time()
         rows = rows.to_dict("records")
         return rows, t2 - t1

--- a/ibis_tpc/runners.py
+++ b/ibis_tpc/runners.py
@@ -121,8 +121,8 @@ class SqliteRunner(Runner):
 class DuckDBRunner(Runner):
     def setup(self, db="tpch.ddb"):
         super().setup(db=db)
-        from ibis_substrait.compiler.core import SubstraitCompiler
         import duckdb
+        from ibis_substrait.compiler.core import SubstraitCompiler
 
         self.con = duckdb.connect(db)
 

--- a/ibis_tpc/runners.py
+++ b/ibis_tpc/runners.py
@@ -32,7 +32,8 @@ def fmt(v):
 
 def out_txt(s, outdir, fn):
     if outdir:
-        print(s, file=open(Path(outdir) / fn, mode="w"), flush=True)
+        with open(Path(outdir) / fn, mode="w") as f:
+            print(s, file=f, flush=True)
 
 
 def out_sql(sql, outdir, fn):
@@ -99,7 +100,7 @@ class SqliteRunner(Runner):
     def run(self, qid, outdir=None, backend="sqlite"):
         cur = self.con.cursor()
 
-        sql = open(f"sqlite_tpc/{qid}.sql").read()
+        sql = Path(f"sqlite_tpc/{qid}.sql").read_text()
         t1 = time.time()
         cur.execute(sql)
         rows = cur.fetchall()
@@ -128,7 +129,7 @@ class DuckDBRunner(Runner):
     def run(self, qid, outdir=None, backend="duckdb"):
         cur = self.con.cursor()
 
-        sql = open(f"sqlite_tpc/{qid}.sql").read()
+        sql = Path(f"sqlite_tpc/{qid}.sql").read_text()
         t1 = time.time()
         cur.execute(sql)
         rows = cur.fetch_arrow_table().to_pandas()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ click
 pandas
 ibis-framework[sqlite,duckdb]
 ibis-substrait
+pyarrow>=9.0.0
 sqlparse
 python-dateutil
 duckdb>=0.4.0


### PR DESCRIPTION
Use pyarrow>=9.0.0 for better typing precision. Related to https://github.com/ibis-project/ibis/pull/4203.