### PR TITLE
fix(substrait): remove extraneous dbgen call

### DIFF
--- a/ibis_tpc/runners.py
+++ b/ibis_tpc/runners.py
@@ -128,7 +128,6 @@ class DuckDBRunner(Runner):
     def setup(self, db="tpch.ddb"):
         super().setup(db=db)
         import duckdb
-        from ibis_substrait.compiler.core import SubstraitCompiler
 
         self.con = duckdb.connect(db)
 
@@ -194,9 +193,6 @@ class SubstraitRunner(Runner):
         except Exception:
             raise ValueError("can't compile")
 
-        # The self.con.con here points to the underlying DuckDB connection
-        self.con.con.execute("install substrait")
-        self.con.con.execute("load substrait")
         results = self.con.con.from_substrait(proto.SerializeToString())
         rows = results.to_df()
         t2 = time.time()

--- a/ibis_tpc/substrait.py
+++ b/ibis_tpc/substrait.py
@@ -6,14 +6,14 @@ from ibis.backends.base import BaseBackend
 
 
 class TPCHBackend(BaseBackend):  # noqa: D101
-    def __init__(self, fname="", scale_factor=0.1):  # noqa: D107
+    def __init__(self, fname="", scale_factor=0.2):  # noqa: D107
         if fname:
             con = ibis.duckdb.connect(fname)
         else:
             con = ibis.duckdb.connect()
 
         if not fname:
-            con.raw_sql(f"CALL dbgen(sf={scale_factor})")
+            con.raw_sql("CALL dbgen(sf=0)")
 
         self.tables = {
             name: con.tables.get(name).unbind() for name in con.list_tables()
@@ -23,7 +23,9 @@ class TPCHBackend(BaseBackend):  # noqa: D101
         self.con = duckdb.connect(fname)
         self.con.install_extension("substrait")
         self.con.load_extension("substrait")
-        self.con.execute(f"CALL dbgen(sf={scale_factor})")
+        if not fname:
+            self.con.execute(f"CALL dbgen(sf={scale_factor})")
+            # sf ~< 0.17 won't necessarily generate any results for certain queries
 
     def table(self, table):  # noqa: D102
         return self.tables.get(table)


### PR DESCRIPTION
This took me an infuriatingly long time to find.
Anyway, if you regenerate the tpch data mid-run, you might get some funky answers, so let us NOT DO THAT.

Also removing some unneeded imports and extension loads.