### PR TITLE
use sqlglot and fix diffs

### DIFF
--- a/ibis_tpc/runners.py
+++ b/ibis_tpc/runners.py
@@ -334,6 +334,18 @@ def _compare(v1, v2, row=None, key=None):
         return f"[{row}].{key} (date) {v1} != {v2}"
 
 
+@dispatch(pandas.Timestamp, datetime.date)
+def _compare(v1, v2, row=None, key=None):
+    if v1.date() != v2:
+        return f"[{row}].{key} (date) {v1} != {v2}"
+
+
+@dispatch(datetime.date, pandas.Timestamp)
+def _compare(v1, v2, row=None, key=None):
+    if v1 != v2.date():
+        return f"[{row}].{key} (date) {v1} != {v2}"
+
+
 @dispatch(str, pandas.Timestamp)
 def _compare(v1, v2, row=None, key=None):  # noqa: F811
     v1 = pandas.to_datetime(v1)

--- a/ibis_tpc/tests/test_substrait.py
+++ b/ibis_tpc/tests/test_substrait.py
@@ -49,11 +49,6 @@ serialize_deserialize = [
         {"DATE": date(1995, 1, 1)},
         marks=[
             pytest.mark.xfail(
-                condition=vparse.parse(duckdb.__version__) > vparse.parse("0.7.1"),
-                raises=duckdb.InternalException,
-                reason="Unsupported expression type 0",
-            ),
-            pytest.mark.xfail(
                 condition=vparse.parse(duckdb.__version__) <= vparse.parse("0.7.1"),
                 raises=RuntimeError,
                 reason="DuckDB fails to load Substrait Plan",
@@ -70,9 +65,6 @@ serialize_deserialize = [
     pytest.param(
         ibis_tpc.h09.tpc_h09,
         {},
-        marks=pytest.mark.xfail(
-            reason="duckdb INTERNAL Error: Substrait type not yet supported"
-        ),
     ),
     pytest.param(
         ibis_tpc.h10.tpc_h10,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ pandas
 ibis-framework[sqlite,duckdb]
 ibis-substrait
 pyarrow>=9.0.0
-sqlparse
 python-dateutil
 duckdb>=0.4.0
 duckdb-engine


### PR DESCRIPTION
This PR ensures that timestamps are compared to dates when they are output from either ibis or duckdb